### PR TITLE
## 3.1.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,18 @@
+name: Test
+on:
+  pull_request:
+    branches: [ master ]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dart
+        uses: dart-lang/setup-dart@v1
+
+      - name: Fetch dependencies
+        run: dart pub get
+
+      - name: Test package
+        run: dart test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.0
+- Added support for exporting dart core libraries
+  - Please change from 'library/file' to 'package:library/file.dart'. (The old version remains supported)
+
 ## 3.0.0
 ### STABLE RELEASE
 - Improve filters, now support a Glob expression

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ index_generator:
         - 'src/**'
       # You can define specific export dart packages in index file.
       exports:
-        - package: args/args
+        - package: package:args/args.dart
           show:
             - ArgResults
           hide:
@@ -57,7 +57,7 @@ index_generator:
 - **include** | **exclude**: You can define filters that exclude or include files to be included in the index. The filters are passed paths relative to the 
   index file. You can use [Glob](https://pub.dev/packages/glob) expressions.
 - **exports**: You can define specific export dart packages in index file. 
-  You can use `package` to export a dart file package without dart extension.
+  You can use `package` to export a dart file package or dart core library.
 
 ## Features and bugs
 

--- a/bin/index_generator.dart
+++ b/bin/index_generator.dart
@@ -25,19 +25,15 @@ void main(List<String> rawArgs) async {
 
   Print.workInfo('Initializing work space...');
 
-  final project = await ToolBox.loadYaml(toolBox.projectYaml, ProjectSettings.fromJson);
+  final project =
+      await ToolBox.loadYaml(toolBox.projectYaml, ProjectSettings.fromJson);
   final settingsFile = await toolBox.findYaml(settingsPath);
-  final settings = await ToolBox.loadYaml(settingsFile, PackageSettings.fromYaml);
+  final settings =
+      await ToolBox.loadYaml(settingsFile, PackageSettings.fromYaml);
 
   if (canVerbose) {
-    Print.verbose(Stringifier.minimal(
-      identity: ' ',
-      lineBreak: '\n',
-    ).stringify(project));
-    Print.verbose(Stringifier.minimal(
-      identity: ' ',
-      lineBreak: '\n',
-    ).stringify(settings));
+    Print.verbose(Stringifier.minimal().stringify(project));
+    Print.verbose(Stringifier.minimal().stringify(settings));
   }
 
   final generators = settings.indexes.map((index) {

--- a/lib/src/dart_code/dart_export.dart
+++ b/lib/src/dart_code/dart_export.dart
@@ -1,0 +1,38 @@
+class DartExport {
+  final String library;
+  final List<String> show;
+  final List<String> hide;
+
+  const DartExport({
+    required this.library,
+    this.show = const [],
+    this.hide = const [],
+  });
+
+  String toCode({StringBuffer? sb}) {
+    sb ??= StringBuffer();
+    sb.write('export \'');
+
+    if (library.endsWith('.dart')) {
+      sb.write(library);
+    } else {
+      // TODO: Remove support on 4.0.0 version
+      print(
+          '[WARNING]: Please change from \'$library\' to \'package:$library.dart\'');
+      sb.write('package:$library.dart');
+    }
+    sb.write('\'');
+
+    if (show.isNotEmpty) {
+      sb
+        ..write(' show ')
+        ..write(show.join(', '));
+    }
+    if (hide.isNotEmpty) {
+      sb
+        ..write(' hide ')
+        ..write(hide.join(', '));
+    }
+    return (sb..write(';')).toString();
+  }
+}

--- a/lib/src/index_generator.dart
+++ b/lib/src/index_generator.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:index_generator/src/dart_code/dart_export.dart';
 import 'package:index_generator/src/settings/index_settings.dart';
 import 'package:index_generator/src/settings/package_settings.dart';
 import 'package:path/path.dart' as path;
@@ -41,7 +42,8 @@ class IndexGenerator {
     PackageSettings package,
     IndexSettings index,
   ) {
-    final indexPath = path.join(index.path, '${_resolveIndexName(project, package, index)}.dart');
+    final indexPath = path.join(
+        index.path, '${_resolveIndexName(project, package, index)}.dart');
     return IndexGenerator._(
       project: project,
       package: package,
@@ -80,7 +82,8 @@ class IndexGenerator {
     return files.where((file) {
       final filePath = getRelativeUnixPath(file);
 
-      final isIncluded = include.isEmpty || include.any((f) => f.matches(filePath));
+      final isIncluded =
+          include.isEmpty || include.any((f) => f.matches(filePath));
       if (!isIncluded) return false;
 
       final isExcluded = exclude.any((f) => f.matches(filePath));
@@ -97,26 +100,26 @@ class IndexGenerator {
     });
   }
 
-  Iterable<String> packageToExport(List<ExportSettings> exports) {
-    return exports.map((export) {
-      var str = "export 'package:${export.package}.dart'";
-      if (export.show.isNotEmpty) {
-        str += ' show ${export.show.join(', ')}';
-      }
-      if (export.hide.isNotEmpty) {
-        str += ' hide ${export.hide.join(', ')}';
-      }
-      return "$str;";
-    });
+  Iterable<String> packagesToExports(List<ExportSettings> exports) {
+    return exports.map(_packageToExport);
+  }
+
+  String _packageToExport(ExportSettings export) {
+    return DartExport(
+      library: export.package,
+      show: export.show,
+      hide: export.hide,
+    ).toCode();
   }
 
   /// Generate a index file content
   Iterable<String> generate() {
-    final externalExports = packageToExport(index.exports).toList()..sort();
+    final externalExports = packagesToExports(index.exports).toList()..sort();
 
     final internalFiles = findFiles();
     final internalFilteredFiles = filterFiles(internalFiles);
-    final internalExports = fileToExport(internalFilteredFiles).toList()..sort();
+    final internalExports = fileToExport(internalFilteredFiles).toList()
+      ..sort();
 
     return [
       '// GENERATED CODE - DO NOT MODIFY BY HAND',

--- a/lib/src/settings/package_settings.dart
+++ b/lib/src/settings/package_settings.dart
@@ -1,5 +1,5 @@
 import 'package:glob/glob.dart';
-import 'package:index_generator/index_generator.dart';
+import 'package:index_generator/src/converters.dart';
 import 'package:index_generator/src/settings/index_settings.dart';
 import 'package:index_generator/src/stringify.dart';
 import 'package:json_annotation/json_annotation.dart';
@@ -34,7 +34,8 @@ class PackageSettings implements Stringify {
     required this.indexes,
   });
 
-  static PackageSettings fromYaml(Map map) => GeneralSettings.fromJson(map).indexGenerator;
+  static PackageSettings fromYaml(Map map) =>
+      GeneralSettings.fromJson(map).indexGenerator;
 
   factory PackageSettings.fromJson(Map map) => _$PackageSettingsFromJson(map);
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: index_generator
 description: Automatically generate index / barrel / library files with all the export needed for your library.
-version: 3.0.0
+version: 3.1.0
 homepage: https://github.com/BreX900/index_generator
 
 # dart pub publish --dry-run
@@ -12,24 +12,24 @@ dependencies:
   console: ^4.1.0
   args: ^2.3.0
 
-  path: ^1.8.0
+  path: ^1.8.1
 
   yaml: ^3.1.0
   checked_yaml: ^2.0.1
-  json_annotation: ^4.1.0
-  glob: ^2.0.1
+  json_annotation: ^4.4.0
+  glob: ^2.0.2
 
   pubspec: ^2.0.1
 
 dev_dependencies:
   lints: ^1.0.1
 
-  test: ^1.17.12
+  test: ^1.20.1
 
   # To generate .g files:
   # dart run build_runner build --delete-conflicting-outputs
   # dart run build_runner watch --delete-conflicting-outputs
-  build_runner: ^2.1.2
-  json_serializable: ^5.0.2
+  build_runner: ^2.1.7
+  json_serializable: ^6.1.3
 
 

--- a/test/dart_export_test.dart
+++ b/test/dart_export_test.dart
@@ -1,0 +1,54 @@
+import 'package:index_generator/src/dart_code/dart_export.dart';
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+
+void main() {
+  group('test DartExport class', () {
+    test('Export only library', () {
+      final export = DartExport(
+        library: 'package:example/example.dart',
+      );
+
+      expect(export.toCode(), 'export \'package:example/example.dart\';');
+    });
+
+    test('Export library and show MyClass', () {
+      final export = DartExport(
+        library: 'package:example/example.dart',
+        show: ['MyClass'],
+      );
+
+      expect(export.toCode(),
+          'export \'package:example/example.dart\' show MyClass;');
+    });
+
+    test('Export library and hide myFunction', () {
+      final export = DartExport(
+        library: 'package:example/example.dart',
+        hide: ['myFunction'],
+      );
+
+      expect(export.toCode(),
+          'export \'package:example/example.dart\' hide myFunction;');
+    });
+
+    test('Export library and show MyClass and hide myFunction', () {
+      final export = DartExport(
+        library: 'package:example/example.dart',
+        show: ['MyClass'],
+        hide: ['myFunction'],
+      );
+
+      expect(export.toCode(),
+          'export \'package:example/example.dart\' show MyClass hide myFunction;');
+    });
+
+    test('Old support', () {
+      final export = DartExport(
+        library: 'example/example',
+      );
+
+      expect(export.toCode(), 'export \'package:example/example.dart\';');
+    });
+  });
+}


### PR DESCRIPTION
- Added support for exporting dart core libraries
  - Please change from 'library/file' to 'package:library/file.dart'. (The old version remains supported)

Fix #3 