### PR TITLE
Add Support for Package Imports and Custom Output Path for Index File

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Index Generator
+
 Automatically generate index / barrel files with all the exports needed for your library.
 
 ### Stable release
+
 There will be no more breaking changes
 
 ## Usage
@@ -9,10 +11,11 @@ There will be no more breaking changes
 1. Activate: `dart/flutter pub global activate index_generator`
 
 2. Create `index_generator.yaml` file or add in your `pubspec.yaml` file:
+
 ```yaml
 index_generator:
   exclude:
-    - '**.g.dart'
+    - "**.g.dart"
   # Define the paths of the folders in which to generate the index files
   libraries:
     - directory_path: lib
@@ -30,14 +33,14 @@ index_generator:
   default_file_name: barrel
   # You can define general filters for all indexes
   exclude:
-    - '**.g.dart'
-    - '{_,**/_}*.dart'
+    - "**.g.dart"
+    - "{_,**/_}*.dart"
   libraries:
     - directory_path: lib
       # You can define specific filters for this index
       include:
         # You can define specific export folders paths
-        - 'src/**'
+        - "src/**"
       # You can define specific export dart packages in index file.
       exports:
         - package: package:args/args.dart
@@ -57,11 +60,13 @@ index_generator:
         Copyright (c) 2020 BreX900
       # Documentation added on the generated file above the library name
       # Note: docs are only included when include_library is true
-      docs: | 
+      docs: |
         Automatically generate index / barrel / library files
         with all the export needed for your library.
       # You can define the name of the library to use within the index
       name: index_generator
+      # Use package-style exports for internal files (e.g., 'package:app/main.dart' instead of 'main.dart')
+      use_package_exports: true
 ```
 
 - **directory_path**: Path in which to create the index file. All filters will get the relative path from this directory
@@ -70,32 +75,34 @@ index_generator:
 - **name**: The name of the library used in the index dart file by the `library` keyword
 - **include_library**: Include or exclude the `library` keyword in the generated file. Defaults to `true`
 - **docs**: Documentation comments added above the library declaration. Only included when `include_library` is `true`
-- **include** | **exclude**: You can define filters that exclude or include files to be included in the index. The filters are passed paths relative to the 
+- **include** | **exclude**: You can define filters that exclude or include files to be included in the index. The filters are passed paths relative to the
   index file. You can use [Glob](https://pub.dev/packages/glob) expressions.
-- **exports**: You can define specific export dart packages in index file. 
+- **exports**: You can define specific export dart packages in index file.
   You can use `package` to export a dart file package or dart core library.
+- **use_package_exports**: When enabled, generates package-style exports for internal files (e.g., `'package:app/main.dart'` instead of `'main.dart'`).
+  This is useful for libraries that want to ensure consistent import paths. Defaults to `false`.
 
 ## Command
+
 `--help` command output:
+
 ```
 -s, --settings=<Define a yaml file path.>    If not present use the "index_generator.yaml" file if it exists otherwise use the "pubspec.yaml" file.
 -v, --[no-]verbose                           Print verbose logs
--h, --help 
+-h, --help
 ```
 
-## Build runner 
+## Build runner
 
 `index_generator` can be run via [build_runner](https://pub.dev/packages/build_runner). To do so, add the following dependancies:
 
 ```yaml
 dev_dependencies:
   build_runner: ^2.3.3
-  index_generator: ^3.5.0 
+  index_generator: ^3.5.0
 ```
 
 To generate use `<dart|flutter> pub run build_runner <build|watch>`
-
-
 
 ## Features and bugs
 

--- a/README.md
+++ b/README.md
@@ -67,9 +67,13 @@ index_generator:
       name: index_generator
       # Use package-style exports for internal files (e.g., 'package:app/main.dart' instead of 'main.dart')
       use_package_exports: true
+      # Custom output path for the generated index file (optional)
+      # If not specified, the file will be created in the directory_path
+      output_path: lib/generated
 ```
 
 - **directory_path**: Path in which to create the index file. All filters will get the relative path from this directory
+- **output_path**: Custom output path for the generated index file. If not specified, the file will be created in the directory_path
 - **file_name**: Prioritize ownership in folders, otherwise it will use the one defined in the generator with `default_file_name` key.
   If it is missing, if the folder is `lib` it will use the package name otherwise the folder name
 - **name**: The name of the library used in the index dart file by the `library` keyword
@@ -87,9 +91,11 @@ index_generator:
 `--help` command output:
 
 ```
--s, --settings=<Define a yaml file path.>    If not present use the "index_generator.yaml" file if it exists otherwise use the "pubspec.yaml" file.
--v, --[no-]verbose                           Print verbose logs
+
+-s, --settings=<Define a yaml file path.> If not present use the "index_generator.yaml" file if it exists otherwise use the "pubspec.yaml" file.
+-v, --[no-]verbose Print verbose logs
 -h, --help
+
 ```
 
 ## Build runner

--- a/example/index_generator.yaml
+++ b/example/index_generator.yaml
@@ -25,6 +25,11 @@ index_generator:
             - basenameWithoutExtension
             - canonicalize
             - withoutExtension
+    # Custom output path example
+    - directory_path: lib/src
+      output_path: lib/generated
+      file_name: api_index
+      name: api_library
     - directory_path: lib
       file_name: docs
       disclaimer: false

--- a/lib/index_generator.dart
+++ b/lib/index_generator.dart
@@ -1,10 +1,11 @@
 /// Automatically generate index / barrel / library files
 /// with all the export needed for your library.
-library index_generator;
+library;
 
-export 'src/builder.dart';
-export 'src/converters.dart';
-export 'src/dart_code/dart_export.dart';
-export 'src/index_generator.dart';
-export 'src/settings/library_settings.dart';
-export 'src/settings/package_settings.dart';
+export 'package:index_generator/src/builder.dart';
+export 'package:index_generator/src/converters.dart';
+export 'package:index_generator/src/dart_code/dart_export.dart';
+export 'package:index_generator/src/index_generator.dart';
+export 'package:index_generator/src/settings/dart.dart';
+export 'package:index_generator/src/settings/library_settings.dart';
+export 'package:index_generator/src/settings/package_settings.dart';

--- a/lib/src/index_generator.dart
+++ b/lib/src/index_generator.dart
@@ -89,7 +89,11 @@ class IndexGenerator {
     return files.map((file) {
       final filePath = getRelativeUnixPath(file);
 
-      return "export '$filePath';";
+      if (library.usePackageExports) {
+        return "export 'package:${pubspec.name}/$filePath';";
+      } else {
+        return "export '$filePath';";
+      }
     });
   }
 

--- a/lib/src/index_generator.dart
+++ b/lib/src/index_generator.dart
@@ -33,8 +33,9 @@ class IndexGenerator {
     PackageSettings package,
     LibrarySettings index,
   ) {
+    final outputDirectoryPath = index.getOutputDirectoryPath();
     final indexPath = path.join(
-      index.directoryPath,
+      outputDirectoryPath,
       '${index.resolveFileName(pubspec.name, package.defaultFileName)}.dart',
     );
     return IndexGenerator._(
@@ -76,7 +77,8 @@ class IndexGenerator {
     return files.where((file) {
       final filePath = getRelativeUnixPath(file);
 
-      final isIncluded = include.isEmpty || include.any((f) => f.matches(filePath));
+      final isIncluded =
+          include.isEmpty || include.any((f) => f.matches(filePath));
       if (!isIncluded) return false;
 
       final isExcluded = exclude.any((f) => f.matches(filePath));
@@ -118,7 +120,8 @@ class IndexGenerator {
 
     final internalFiles = findFiles();
     final internalFilteredFiles = filterFiles(internalFiles);
-    final internalExports = fileToExport(internalFilteredFiles).toList()..sort();
+    final internalExports = fileToExport(internalFilteredFiles).toList()
+      ..sort();
 
     final name = library.name;
     return [

--- a/lib/src/settings/library_settings.dart
+++ b/lib/src/settings/library_settings.dart
@@ -40,6 +40,9 @@ class LibrarySettings with _$LibrarySettings {
   /// Black filters
   final List<Glob> exclude;
 
+  /// Use package-style exports for internal files (e.g., 'package:app/main.dart' instead of 'main.dart')
+  final bool usePackageExports;
+
   const LibrarySettings({
     required this.directoryPath,
     this.fileName,
@@ -51,6 +54,7 @@ class LibrarySettings with _$LibrarySettings {
     this.exports = const <ExportSettings>[],
     this.include = const <Glob>[],
     this.exclude = const <Glob>[],
+    this.usePackageExports = false,
   });
 
   String resolveFileName(String projectName, String? defaultFileName) {

--- a/lib/src/settings/library_settings.dart
+++ b/lib/src/settings/library_settings.dart
@@ -13,6 +13,10 @@ class LibrarySettings with _$LibrarySettings {
   /// Folder path to create a index file
   final String directoryPath;
 
+  /// Custom output path for the generated index file (optional)
+  /// If not specified, the file will be created in the directoryPath
+  final String? outputPath;
+
   /// File name with extension
   final String? fileName;
 
@@ -45,6 +49,7 @@ class LibrarySettings with _$LibrarySettings {
 
   const LibrarySettings({
     required this.directoryPath,
+    this.outputPath,
     this.fileName,
     this.disclaimer = true,
     this.includeLibrary = true,
@@ -67,6 +72,11 @@ class LibrarySettings with _$LibrarySettings {
     if (defaultFileName != null) return defaultFileName;
 
     return dirName;
+  }
+
+  /// Get the output directory path for the generated index file
+  String getOutputDirectoryPath() {
+    return outputPath ?? directoryPath;
   }
 
   factory LibrarySettings.fromJson(Map map) => _$LibrarySettingsFromJson(map);

--- a/lib/src/settings/library_settings.g.dart
+++ b/lib/src/settings/library_settings.g.dart
@@ -14,6 +14,7 @@ mixin _$LibrarySettings {
       other is LibrarySettings &&
           runtimeType == other.runtimeType &&
           _self.directoryPath == other.directoryPath &&
+          _self.outputPath == other.outputPath &&
           _self.fileName == other.fileName &&
           _self.disclaimer == other.disclaimer &&
           _self.includeLibrary == other.includeLibrary &&
@@ -28,6 +29,7 @@ mixin _$LibrarySettings {
   int get hashCode {
     var hashCode = 0;
     hashCode = $hashCombine(hashCode, _self.directoryPath.hashCode);
+    hashCode = $hashCombine(hashCode, _self.outputPath.hashCode);
     hashCode = $hashCombine(hashCode, _self.fileName.hashCode);
     hashCode = $hashCombine(hashCode, _self.disclaimer.hashCode);
     hashCode = $hashCombine(hashCode, _self.includeLibrary.hashCode);
@@ -44,6 +46,7 @@ mixin _$LibrarySettings {
   @override
   String toString() => (ClassToString('LibrarySettings')
         ..add('directoryPath', _self.directoryPath)
+        ..add('outputPath', _self.outputPath)
         ..add('fileName', _self.fileName)
         ..add('disclaimer', _self.disclaimer)
         ..add('includeLibrary', _self.includeLibrary)
@@ -96,6 +99,7 @@ LibrarySettings _$LibrarySettingsFromJson(Map json) => $checkedCreate(
           json,
           allowedKeys: const [
             'directory_path',
+            'output_path',
             'file_name',
             'disclaimer',
             'include_library',
@@ -110,6 +114,7 @@ LibrarySettings _$LibrarySettingsFromJson(Map json) => $checkedCreate(
         );
         final val = LibrarySettings(
           directoryPath: $checkedConvert('directory_path', (v) => v as String),
+          outputPath: $checkedConvert('output_path', (v) => v as String?),
           fileName: $checkedConvert('file_name', (v) => v as String?),
           disclaimer: $checkedConvert('disclaimer', (v) => v as bool? ?? true),
           includeLibrary:
@@ -147,6 +152,7 @@ LibrarySettings _$LibrarySettingsFromJson(Map json) => $checkedCreate(
       },
       fieldKeyMap: const {
         'directoryPath': 'directory_path',
+        'outputPath': 'output_path',
         'fileName': 'file_name',
         'includeLibrary': 'include_library',
         'usePackageExports': 'use_package_exports'

--- a/lib/src/settings/library_settings.g.dart
+++ b/lib/src/settings/library_settings.g.dart
@@ -22,7 +22,8 @@ mixin _$LibrarySettings {
           _self.name == other.name &&
           $listEquality.equals(_self.exports, other.exports) &&
           $listEquality.equals(_self.include, other.include) &&
-          $listEquality.equals(_self.exclude, other.exclude);
+          $listEquality.equals(_self.exclude, other.exclude) &&
+          _self.usePackageExports == other.usePackageExports;
   @override
   int get hashCode {
     var hashCode = 0;
@@ -36,6 +37,7 @@ mixin _$LibrarySettings {
     hashCode = $hashCombine(hashCode, $listEquality.hash(_self.exports));
     hashCode = $hashCombine(hashCode, $listEquality.hash(_self.include));
     hashCode = $hashCombine(hashCode, $listEquality.hash(_self.exclude));
+    hashCode = $hashCombine(hashCode, _self.usePackageExports.hashCode);
     return $hashFinish(hashCode);
   }
 
@@ -50,7 +52,8 @@ mixin _$LibrarySettings {
         ..add('name', _self.name)
         ..add('exports', _self.exports)
         ..add('include', _self.include)
-        ..add('exclude', _self.exclude))
+        ..add('exclude', _self.exclude)
+        ..add('usePackageExports', _self.usePackageExports))
       .toString();
 }
 
@@ -101,7 +104,8 @@ LibrarySettings _$LibrarySettingsFromJson(Map json) => $checkedCreate(
             'name',
             'exports',
             'include',
-            'exclude'
+            'exclude',
+            'use_package_exports'
           ],
         );
         final val = LibrarySettings(
@@ -136,13 +140,16 @@ LibrarySettings _$LibrarySettingsFromJson(Map json) => $checkedCreate(
                           const GlobJsonConverter().fromJson(e as String))
                       .toList() ??
                   const <Glob>[]),
+          usePackageExports: $checkedConvert(
+              'use_package_exports', (v) => v as bool? ?? false),
         );
         return val;
       },
       fieldKeyMap: const {
         'directoryPath': 'directory_path',
         'fileName': 'file_name',
-        'includeLibrary': 'include_library'
+        'includeLibrary': 'include_library',
+        'usePackageExports': 'use_package_exports'
       },
     );
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,8 +49,8 @@ index_generator:
   exclude:
     - "**.g.dart"
     - "{_,**/_}*.dart"
-  indexes:
-    - path: lib
+  libraries:
+    - directory_path: lib
       disclaimer: false
       docs: |
         Automatically generate index / barrel / library files


### PR DESCRIPTION
This PR adds support for two new properties:

1. `use_package_support`: Enables package-style imports.
2. `output_path`: Allows setting a custom directory for the generated index file.

Enabling both lets us export the index file for use in other projects. The main motivation is to **prevent using this file within the same library** and instead make it consumable by other packages in the monorepo (e.g., the `widgetbook` project).
