### PR TITLE
chore: Upgrade build dependency to v4.0 for build_runner 2.10.0 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ index_generator:
 
 ```yaml
 dev_dependencies:
-  build_runner: ^2.3.3
-  index_generator: ^3.5.0
+  build_runner: ^2.10.0
+  index_generator: ^4.1.0
 ```
 
 and enable it in `build.yaml` file

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
 
   dart_style: ^3.0.0
   pub_semver: ^2.0.0
-  build: ^3.0.0
+  build: ^4.0.0
 
 dev_dependencies:
   mek_lints: ^5.0.0


### PR DESCRIPTION
## Summary
Update the `build` package dependency from `^3.0.0` to `^4.0.0` to enable compatibility with the latest `build_runner` version.

## Background
The `build_runner` 2.10.0 release introduced significant performance improvements through AOT (Ahead-of-Time) compiler optimizations. However, projects using `index_generator` were unable to upgrade to `build_runner` 2.10.0 due to dependency conflicts - `index_generator` was constrained to `build` version 3.x, while `build_runner` 2.10.0+ requires `build` version 4.x.

This update resolves the version conflict and allows users to benefit from the build_runner performance improvements.

## Changes
- ✅ Updated `build` dependency from `^3.0.0` to `^4.0.0` in `pubspec.yaml`
- ✅ Updated recommended `build_runner` version in README from `^2.3.3` to `^2.10.0`
- ✅ All existing tests pass with no code changes required

## Motivation
- Unlock access to build_runner 2.10.0's AOT compiler performance benefits
- Resolve dependency conflicts preventing users from upgrading their build toolchain
- Maintain compatibility with the latest Dart ecosystem tooling

## Backward Compatibility
- ✅ Fully backward compatible - no breaking changes to the public API
- ✅ No changes to generated code output
- ✅ Existing configurations continue to work without modification

## Testing
- ✅ All existing unit tests pass
- ✅ Verified compatibility with `build_runner` 2.10.0
- ✅ No behavioral changes observed in code generation